### PR TITLE
[Feature][Floreta] add server data fetching to residential property

### DIFF
--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -19,7 +19,7 @@ function Dashboard() {
       case 2:
         return <Contacts />;
       case 3:
-        return <ResidentialProperties />;
+        return <ResidentialProperties residentialProp={[]} />;
       case 4:
         return <LandProperties />;
       case 5:

--- a/pagination/ResidentialProperties/index.tsx
+++ b/pagination/ResidentialProperties/index.tsx
@@ -6,6 +6,7 @@ import style from '../_index.module.scss';
 import { AppCard, FilterPicker, Search } from '../../components';
 import PropertyType from '../../enums/PropertyType.enum';
 import { usePropertyContext } from '../../hooks/PropertyContext';
+import { sanityClient } from '../../sanity';
 import { Property } from '../../types';
 
 function ResidentialProperties() {
@@ -61,3 +62,30 @@ function ResidentialProperties() {
 }
 
 export default ResidentialProperties;
+
+export const serverSideProps = async () => {
+  const query = `*[_type == "property"] | order(dateRegistered desc) {
+    _id,
+    title,
+    dateRegistered,
+    slug,
+    homeowner-> {
+      name,
+      image,
+      contactDetails,
+      dateRegistered
+    },
+    categories,
+    vehicles,
+    description,
+    mainImage
+  }`;
+
+  const residentialProperties = sanityClient.fetch(query);
+
+  return {
+    props: {
+      residentialProperties,
+    }
+  }
+}

--- a/pagination/ResidentialProperties/index.tsx
+++ b/pagination/ResidentialProperties/index.tsx
@@ -9,7 +9,11 @@ import { usePropertyContext } from '../../hooks/PropertyContext';
 import { sanityClient } from '../../sanity';
 import { Property } from '../../types';
 
-function ResidentialProperties() {
+interface ResidentialProp {
+  residentialProp: Property[];
+}
+
+function ResidentialProperties({ residentialProp }: ResidentialProp) {
   const { properties, setPropertyType } = usePropertyContext();
   setPropertyType(PropertyType.RESIDENTIAL);
 


### PR DESCRIPTION
- adds the server code for handling the data fetching of residential information to the page, ready for consumption
- this shall be soon updated to replace the current temporary data being supplied from the useContext hook, awaiting the schema update based on pseudodata.ts